### PR TITLE
corrects the cargo instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently, we only support installing trough cargo.
 To install, you need to run:
 
 ```bash
-cargo install git@github.com:astronvim/astrocommunity-cli
+cargo install --git https://github.com/AstroNvim/astrocommunity-cli
 ```
 
 ## 🔨 Usage


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The current install instruction fails. I am new to `cargo`, so maybe this used to work, but I am on a recent version.



## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

```
rustup --version                                               
rustup 1.27.1 (54dd3d00f 2024-04-24)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.79.0 (129f3b996 2024-06-10)`
```